### PR TITLE
Add bash script to create SMP files for Storyland in a single command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+encrypted

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,9 @@ Picture | ID | Name | Description
 [![](https://oyooyo.github.io/audiocube/devices/storyland/image-0001-256x256.jpg)](https://oyooyo.github.io/audiocube/devices/storyland/) | [storyland](https://oyooyo.github.io/audiocube/devices/storyland/) | LIDL Storyland | Sold by LIDL in Greece
 [![](https://oyooyo.github.io/audiocube/devices/storybox/image-0001-256x256.jpg)](https://oyooyo.github.io/audiocube/devices/storybox/) | [storybox](https://oyooyo.github.io/audiocube/devices/storybox/) | Migros Storybox | Sold by Migros in Switzerland
 
+Read [about helper scripts](scripts.md) that can facilitate tasks like encrypting a file with
+a proper ID3 tag.
+
 ## Alternatives
 
 - [smp2mp3](https://github.com/ZapDissaster/smp2mp3/) by ZapDissaster is a very similar software tool with a GUI for Windows, that is probably easier to get running for Windows users who have little experience with using command-line tools

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,39 @@
+# Helper Scripts
+
+## Storyland Encrypter
+
+A bash script to facilitate encrypting any mp3 file into a storyland compatible
+exists under the `scripts` folder.
+
+### Requirements
+
+- audiocube
+- [eyed3](https://eyed3.readthedocs.io/en/latest/) (`apt install eyed3`)
+
+Created and tested on Linux systems, but should be possible to port.
+
+### Usage
+
+Execute the script with:
+
+```bash
+cd scripts
+./storyland_encrypter.sh /path/to/file.mp3 17
+```
+
+to convert `file.mp3` into `L0017.SMP`. ID3 tags will be automatically set to
+create a compatible file and a CSV file with the NFC data will be created under
+the `encrypted` folder.
+
+
+Alternatively use:
+
+```bash
+cd scripts
+./storyland_encrypter.sh /path/to/file.mp3 17 --nonfc
+```
+
+to not create the CSV file containing NFC data.
+
+In both cases, an `index.txt` file holding information for the file will be created.
+If the `index` file exists, new information will be appended.

--- a/scripts/storyland_encrypter.sh
+++ b/scripts/storyland_encrypter.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Parameters:
+# - path to mp3 file
+# - an integer (1 to 9999)
+# - optional: `--nonfc` flag to not create an nfc csv file
+#
+# Example:
+# ./storyland_encrypter.sh /path/to/file.mp3 17
+# ./storyland_encrypter.sh /path/to/file.mp3 17 --nonfc
+#
+# Inspired by @filiatrag
+# see https://www.insomnia.gr/forums/topic/757427-lidl-storyland-figures/page/21/#comment-59031689
+
+if ! hash eyeD3 &> /dev/null
+then
+  echo "eyed3 needs to be installed (example: 'sudo apt install eyed3')"
+  exit
+fi
+
+if [ -z "$3" ]
+then
+  nfc=1
+else
+  if [ $3 == '--nonfc' ]
+  then
+    nfc=0
+  else
+    nfc=1
+  fi
+fi  
+
+file=$1
+name=$(basename $file)
+name="${name%.*}"
+filenumber=$(printf "%04d\n" $2)
+
+# Prepare NFC code to write in index file (not used in CSV from python script)
+nfc_code="02200408${filenumber}"
+nfc_code="${nfc_code}00"
+
+# Prepare file and sidecar csv
+cp $file L$filenumber.mp3
+eyeD3 --to-v2.3 --encoding utf16 -t L$filenumber L$filenumber.mp3 &> /dev/null
+../audiocube.py storyland encrypt L$filenumber.mp3
+rm L$filenumber.mp3
+if [ $nfc == 1 ]
+then
+  ../audiocube.py storyland create_nfc_file $filenumber
+fi
+
+# Create folder for encrypted files if it does not exist and move files
+[ ! -d "../encrypted" ] && mkdir "../encrypted"
+mv L$filenumber.* ../encrypted/
+
+# Create an index file, to remember what is what
+[ ! -f "../encrypted/index.txt" ] && echo "FILE  - NFC CODE       - ORIGINAL SONG" > ../encrypted/index.txt && echo "--------------------------------------" >> ../encrypted/index.txt
+echo "L$filenumber - $nfc_code - $name" >> ../encrypted/index.txt


### PR DESCRIPTION
Adds a bash script (for linux) that gets a file and an id as arguments and creates a valid SMP file.

- Requires `eyeD3` (package `eyed3` in linux)
- Handles ID3 tags
- Creates an index file where it keeps encrypted files history
- Adds the NFC code in the index file
- Optional flag to not create the nfc csv file

Based on: https://www.insomnia.gr/forums/topic/757427-lidl-storyland-figures/page/21/#comment-59031689